### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ guidedog (1.3.0-2) UNRELEASED; urgency=medium
   * Set debhelper-compat version in Build-Depends.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 17:53:10 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ guidedog (1.3.0-2) UNRELEASED; urgency=medium
     Repository-Browse.
   * Bump debhelper from old 12 to 13.
   * Avoid explicitly specifying -Wl,--as-needed linker flag.
+  * Fix field name case in debian/control (VCS-Git => Vcs-Git).
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 17:53:10 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ guidedog (1.3.0-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Bump debhelper from old 12 to 13.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 17:53:10 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13), qtbase5-dev
 Standards-Version: 4.0.0
 Homepage: https://github.com/antocm/guidedog/wiki
 Vcs-Browser: https://github.com/antocm/guidedog/tree/debian
-VCS-Git: https://github.com/antocm/guidedog/ -b debian
+Vcs-Git: https://github.com/antocm/guidedog/ -b debian
 
 Package: guidedog
 Architecture: linux-any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Antonio Cardoso Martins <digiplan.pt@gmail.com>
 Uploaders: Gianfranco Costamagna <locutusofborg@debian.org>
-Build-Depends: debhelper-compat (= 12), qtbase5-dev
+Build-Depends: debhelper-compat (= 13), qtbase5-dev
 Standards-Version: 4.0.0
 Homepage: https://github.com/antocm/guidedog/wiki
 Vcs-Browser: https://github.com/antocm/guidedog/tree/debian

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,6 @@
 # Uncomment this to turn on verbose mode.
 # export DH_VERBOSE=1
 
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export QT_SELECT = qt5
 
 %:


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))

* Fix field name case in debian/control (VCS-Git => Vcs-Git). ([cute-field](https://lintian.debian.org/tags/cute-field))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/guidedog/f50199a1-cc31-4e77-bbf2-8367ab5f9235.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/f50199a1-cc31-4e77-bbf2-8367ab5f9235/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f50199a1-cc31-4e77-bbf2-8367ab5f9235/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f50199a1-cc31-4e77-bbf2-8367ab5f9235/diffoscope)).
